### PR TITLE
security package jwt module 테스트 코드 추가

### DIFF
--- a/src/main/kotlin/kr/respectme/common/security/jwt/DefaultJwtAuthenticationConfig.kt
+++ b/src/main/kotlin/kr/respectme/common/security/jwt/DefaultJwtAuthenticationConfig.kt
@@ -19,7 +19,7 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder
 
 @Configuration
 @AutoConfiguration
-@ConditionalOnProperty(prefix = "respectme.security.jwt", name = ["enabled"], havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(prefix = "respect-me.security.jwt", name = ["enabled"], havingValue = "true", matchIfMissing = false)
 @EnableFeignClients(clients=[JwtAuthenticationRequirementsRequestAdapter::class])
 class DefaultJwtAuthenticationConfig(
     @Value("\${respect-me.msa.auth-api.url}")

--- a/src/main/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationFilter.kt
@@ -39,7 +39,6 @@ class JwtAuthenticationFilter(
         token?.let{
             try {
                 val jwtAuthentication = jwtAuthenticationProvider.authenticate(JwtAuthenticationToken(token))
-
                 jwtAuthentication?.let { SecurityContextHolder.getContext().authentication = jwtAuthentication }
             } catch(e: JwtAuthenticationException) {
                 logger.error("Exception occur in authentication filter, ${e.message}")

--- a/src/main/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationToken.kt
+++ b/src/main/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationToken.kt
@@ -18,11 +18,11 @@ class JwtAuthenticationToken(private var _principal: Any): AbstractAuthenticatio
     }
 
     override fun isAuthenticated(): Boolean {
-        return !(_principal as JwtAuthentication).isActivated
+        return (_principal as JwtAuthentication).isActivated
     }
 
     override fun setAuthenticated(isAuthenticated: Boolean) {
-
+        this.isAuthenticated = isAuthenticated
     }
 
     override fun getCredentials(): Any? {

--- a/src/main/kotlin/kr/respectme/common/security/jwt/adapter/JwtAuthenticationAdapter.kt
+++ b/src/main/kotlin/kr/respectme/common/security/jwt/adapter/JwtAuthenticationAdapter.kt
@@ -3,6 +3,7 @@ package kr.respectme.common.security.jwt.adapter
 import com.auth0.jwt.JWT
 import com.auth0.jwt.JWTVerifier
 import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.exceptions.IncorrectClaimException
 import kr.respectme.common.security.jwt.JwtClaims
 import kr.respectme.common.security.jwt.adapter.dto.JwtValidateRequest
 import kr.respectme.common.security.jwt.port.JwtAuthenticationPort
@@ -30,9 +31,11 @@ class JwtAuthenticationAdapter(
         logger.info("JwtAuthenticationAdapter generated.")
         try {
             jwtAuthenticationRequirements = getRequirements()
+            logger.info("init requirements: ${jwtAuthenticationRequirements}")
             accessTokenVerifier = JWT.require(getAlgorithm())
                 .withIssuer(jwtAuthenticationRequirements!!.issuer)
                 .build()
+            logger.info("JWT Authentication Adapter Initialization Success : ${jwtAuthenticationRequirements!!.issuer}")
         }catch(e: Exception) {
             logger.error("JWT Authentication Adapter Initialization Failed : ${e.message}")
         }
@@ -45,6 +48,7 @@ class JwtAuthenticationAdapter(
 
         return try {
             val decodedJWT = accessTokenVerifier.verify(jwtValidationRequest.accessToken)
+            logger.info("JWT Verification Success : ${decodedJWT.token} ${decodedJWT.issuer}")
             JwtClaims.valueOf(decodedJWT)
         } catch (e: Exception) {
             logger.error("JWT Verification Failed : ${e.message}")
@@ -56,8 +60,9 @@ class JwtAuthenticationAdapter(
     private fun updateVerifier() {
         jwtAuthenticationRequirements = getRequirements()
         accessTokenVerifier = JWT.require(getAlgorithm())
-            .withIssuer(jwtAuthenticationRequirements!!.issuer)
+            .withIssuer(jwtAuthenticationRequirements?.issuer.toString())
             .build()
+        logger.info("JWT Authentication Adapter Update Success : ${jwtAuthenticationRequirements?.issuer}")
     }
 
     private fun getRequirements(): JwtAuthenticationRequirements {

--- a/src/test/kotlin/kr/respectme/common/security/jwt/DefaultJwtAuthenticationConfigTest.kt
+++ b/src/test/kotlin/kr/respectme/common/security/jwt/DefaultJwtAuthenticationConfigTest.kt
@@ -1,0 +1,65 @@
+package kr.respectme.common.security.jwt
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import kr.respectme.common.security.jwt.port.JwtAuthenticationPort
+import kr.respectme.common.security.jwt.port.JwtAuthenticationRequirementsRequestPort
+
+class DefaultJwtAuthenticationConfigTest : AnnotationSpec() {
+
+    @Test
+    fun `DefaultJwtAuthenticationConfig 생성자 테스트`() {
+        // Given
+        val authApiUrl = "http://localhost:8080"
+        val serviceToken = ""
+
+        // When
+        val defaultJwtAuthenticationConfig = DefaultJwtAuthenticationConfig(
+            authApiUrl = authApiUrl,
+            serviceToken = serviceToken
+        )
+
+        // Then
+        defaultJwtAuthenticationConfig shouldNotBe  null
+    }
+
+    @Test
+    fun `jwtAuthenticationPort Bean 생성 메서드 호출`() {
+        // Given
+        val authApiUrl = "http://localhost:8080"
+        val serviceToken = ""
+        val jwtAuthenticationRequirementsRequestPort = mockk<JwtAuthenticationRequirementsRequestPort>()
+
+        // When
+        val defaultJwtAuthenticationConfig = DefaultJwtAuthenticationConfig(
+            authApiUrl = authApiUrl,
+            serviceToken = serviceToken
+        )
+
+        // Then
+        val jwtAuthenticationPort = shouldNotThrowAny {
+            defaultJwtAuthenticationConfig.jwtAuthenticationPort(jwtAuthenticationRequirementsRequestPort)
+        }
+    }
+
+    @Test
+    fun `jwtAuthenticationProvider Bean 생성 메서드 호출`() {
+        // Given
+        val authApiUrl = "http://localhost:8080"
+        val serviceToken = ""
+        val jwtAuthenticationPort = mockk<JwtAuthenticationPort>()
+
+        // When
+        val defaultJwtAuthenticationConfig = DefaultJwtAuthenticationConfig(
+            authApiUrl = authApiUrl,
+            serviceToken = serviceToken
+        )
+
+        // Then
+        val jwtAuthenticationProvider = shouldNotThrowAny {
+            defaultJwtAuthenticationConfig.jwtAuthenticationProvider(jwtAuthenticationPort)
+        }
+    }
+}

--- a/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationExceptionTest.kt
+++ b/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationExceptionTest.kt
@@ -1,0 +1,20 @@
+package kr.respectme.common.security.jwt
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+
+
+class JwtAuthenticationExceptionTest: AnnotationSpec() {
+
+    @Test
+    fun `test JwtAuthenticationException`() {
+        // Given
+        val message = "Unauthorized access"
+
+        // When
+        val exception = JwtAuthenticationException(message)
+
+        // Then
+        exception.message shouldBe  message
+    }
+}

--- a/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,128 @@
+package kr.respectme.common.security.jwt
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import jakarta.servlet.FilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.util.matcher.RequestMatcher
+
+class JwtAuthenticationFilterTest : AnnotationSpec(){
+
+    private lateinit var mockkObjectMapper: ObjectMapper
+    private lateinit var mockkRequestMatcher: RequestMatcher
+    private lateinit var mockkJwtAuthenticationProvider: JwtAuthenticationProvider
+
+    @BeforeEach
+    fun setUp() {
+        mockkObjectMapper = mockk()
+        mockkRequestMatcher = mockk()
+        mockkJwtAuthenticationProvider = mockk()
+    }
+
+    @Test
+    fun `인증 불필요 URL인 경우 필터를 통과한다`() {
+        // Given
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val filterChain = mockk<FilterChain>(relaxed = true)
+
+        // When
+        every { mockkRequestMatcher.matches(request) } returns true
+        every { filterChain.doFilter(request, response) } returns Unit
+        val filter = JwtAuthenticationFilter(
+            exclusiveRequestMatcher = mockkRequestMatcher,
+            jwtAuthenticationProvider = mockkJwtAuthenticationProvider,
+            objectMapper = mockkObjectMapper
+        )
+
+        // Then
+        shouldNotThrowAny {
+            filter.doFilter(request, response, filterChain)
+        }
+    }
+
+    fun `인증이 필요한 URL에 정상적인 토큰이 주어지면 Authentication이 세팅된다`() {
+        // Given
+        val tokens = "Bearer valid-token-string"
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val filterChain = mockk<FilterChain>(relaxed = true)
+        val authentication = mockk<JwtAuthenticationToken>(relaxed = true)
+        mockkStatic(SecurityContextHolder::class)
+
+        // When
+        every { mockkRequestMatcher.matches(request) } returns false
+        every { request.getHeader("Authorization") } returns tokens
+        every { mockkJwtAuthenticationProvider.authenticate(any()) } returns authentication
+        every { filterChain.doFilter(request, response) } returns Unit
+        every {SecurityContextHolder.getContext().authentication } returns authentication
+
+        val filter = JwtAuthenticationFilter(
+            exclusiveRequestMatcher = mockkRequestMatcher,
+            jwtAuthenticationProvider = mockkJwtAuthenticationProvider,
+            objectMapper = mockkObjectMapper
+        )
+
+        // Then
+        shouldNotThrowAny {
+            filter.doFilter(request, response, filterChain)
+        }
+    }
+
+    fun `인증이 필요한 URL에 비정상적인 토큰이 주어지면 예외가 발생한다`() {
+        // Given
+        val tokens = "Bearer invalid-token-string"
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val filterChain = mockk<FilterChain>(relaxed = true)
+        val authentication = mockk<JwtAuthenticationToken>(relaxed = true)
+
+        // When
+        every { mockkRequestMatcher.matches(request) } returns false
+        every { request.getHeader("Authorization") } returns tokens
+        every { mockkJwtAuthenticationProvider.authenticate(any()) } throws JwtAuthenticationException("Invalid token")
+        val filter = JwtAuthenticationFilter(
+            exclusiveRequestMatcher = mockkRequestMatcher,
+            jwtAuthenticationProvider = mockkJwtAuthenticationProvider,
+            objectMapper = mockkObjectMapper
+        )
+
+        shouldThrow<JwtAuthenticationException> {
+            filter.doFilter(request, response, filterChain)
+        }
+    }
+
+    @Test
+    fun `생성자 테스트`() {
+        // Given
+        val requestMatcher = mockk<RequestMatcher>()
+        val provider = mockk<JwtAuthenticationProvider>()
+        val objectMapper = mockk<ObjectMapper>()
+
+        // When
+        val filter = JwtAuthenticationFilter(
+            exclusiveRequestMatcher = requestMatcher,
+            jwtAuthenticationProvider = provider,
+            objectMapper = objectMapper
+        )
+
+        // Then
+        shouldNotBeNull {
+            filter
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+}

--- a/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationProviderTest.kt
+++ b/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationProviderTest.kt
@@ -1,0 +1,96 @@
+package kr.respectme.common.security.jwt
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import kr.respectme.common.security.jwt.port.JwtAuthenticationPort
+import kr.respectme.common.support.jwt.JwtAuthenticationSupport
+import java.util.*
+
+class JwtAuthenticationProviderTest: AnnotationSpec() {
+
+    private lateinit var jwtAuthenticationPort: JwtAuthenticationPort
+
+    @BeforeEach
+    fun setUp() {
+        // Mocking and setup code here
+         jwtAuthenticationPort = mockk<JwtAuthenticationPort>()
+    }
+
+    @Test
+    fun `생성자 호출 테스트`() {
+        shouldNotThrowAny {
+            val jwtAuthenticationProvider = JwtAuthenticationProvider(jwtAuthenticationPort)
+        }
+    }
+
+    @Test
+    fun `JwtAuthenticationToken 인증 테스트`() {
+        // Given
+        val jwtAuthenticationProvider = JwtAuthenticationProvider(jwtAuthenticationPort)
+        val claims = JwtClaims(
+            memberId = UUID.randomUUID().toString(),
+            email = "test@email.com",
+            roles = listOf("ROLE_USER", "ROLE_ADMIN"),
+            isActivated = true
+        )
+        // When
+        val jwtAuthentication = JwtAuthenticationToken("testToken;")
+        every { jwtAuthenticationPort.verify(any()) } returns claims
+
+        // Then
+        val authentication = jwtAuthenticationProvider.authenticate(jwtAuthentication)
+        authentication shouldNotBe null
+        authentication?.name shouldBe claims.email
+        authentication?.authorities?.forEach { authority ->
+            claims.roles.contains(authority.authority) shouldBe true
+        }
+        authentication?.details.toString() shouldBe claims.memberId
+        authentication?.isAuthenticated shouldBe true
+    }
+
+    @Test
+    fun `authenticate with null 테스트`() {
+        // Given
+        val authentication = null
+
+        // When
+        val jwtAuthenticationProvider = JwtAuthenticationProvider(jwtAuthenticationPort)
+
+        // Then
+        jwtAuthenticationProvider.authenticate(authentication) shouldBe null
+    }
+
+    @Test
+    fun `지원하지 않는 token supports 테스트`() {
+        // Given
+        val token = Any::class.java
+
+        // When
+        val jwtAuthenticationProvider = JwtAuthenticationProvider(jwtAuthenticationPort)
+
+        // Then
+        jwtAuthenticationProvider.supports(token) shouldBe false
+    }
+
+    @Test
+    fun `JwtAuthenticationToken supports 테스트`() {
+
+        // Given
+        val clazz = JwtAuthenticationToken::class.java
+
+        // When
+        val jwtAuthenticationProvider = JwtAuthenticationProvider(jwtAuthenticationPort)
+
+        // Then
+        jwtAuthenticationProvider.supports(clazz) shouldBe  true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // Cleanup code here
+    }
+}

--- a/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationTest.kt
+++ b/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationTest.kt
@@ -1,0 +1,34 @@
+package kr.respectme.common.security.jwt
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import java.util.UUID
+
+class JwtAuthenticationTest : AnnotationSpec(){
+
+    @Test
+    fun `생성자 테스트`() {
+        // Given
+        val id = UUID.randomUUID()
+        val email = "test@email.com"
+        val roles = mutableListOf<GrantedAuthority>(SimpleGrantedAuthority("ROLE_MEMBER"))
+        val isActivated = true
+
+        // When
+        val authentication = JwtAuthentication(
+            id = id,
+            email = email,
+            roles = roles,
+            isActivated = isActivated
+        )
+
+        // Then
+        authentication.id shouldBe id
+        authentication.email shouldBe email
+        authentication.roles shouldBe roles
+        authentication.isActivated shouldBe isActivated
+        authentication.name shouldBe email
+    }
+}

--- a/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationTokenTest.kt
+++ b/src/test/kotlin/kr/respectme/common/security/jwt/JwtAuthenticationTokenTest.kt
@@ -1,0 +1,47 @@
+package kr.respectme.common.security.jwt
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import kr.respectme.common.support.jwt.JwtAuthenticationSupport
+
+
+class JwtAuthenticationTokenTest: AnnotationSpec() {
+
+    @Test
+    fun `정상적인 JwtAuthentication이 넘어간 경우 테스트`() {
+        // Given
+        val authentication = JwtAuthenticationSupport.createJwtAuthentication()
+
+        // When
+        val token = JwtAuthenticationToken(authentication)
+
+        // Then
+        token.name shouldBe  authentication.email
+        token.authorities.forEach { authority ->
+            authentication.roles.contains(authority) shouldBe true
+        }
+        token.details shouldBe authentication.id
+        token.isAuthenticated shouldBe true
+        token.principal shouldBe authentication
+        token.credentials shouldBe null
+    }
+
+    @Test
+    fun `비활성화된 인증 정보인 경우`() {
+        // Given
+        val authentication = JwtAuthenticationSupport.createJwtAuthentication(isActivated = false)
+
+        // When
+        val token = JwtAuthenticationToken(authentication)
+
+        // Then
+        token.name shouldBe authentication.email
+        token.authorities.forEach { authority ->
+            authentication.roles.contains(authority) shouldBe true
+        }
+        token.details shouldBe authentication.id
+        token.isAuthenticated shouldBe false
+        token.principal shouldBe authentication
+        token.credentials shouldBe null
+    }
+}

--- a/src/test/kotlin/kr/respectme/common/security/jwt/JwtClaimsTest.kt
+++ b/src/test/kotlin/kr/respectme/common/security/jwt/JwtClaimsTest.kt
@@ -1,0 +1,31 @@
+package kr.respectme.common.security.jwt
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import java.util.*
+
+class JwtClaimsTest : AnnotationSpec() {
+
+    @Test
+    fun `test JwtClaims`() {
+        // Given
+        val id = UUID.randomUUID()
+        val email = "test@email.com"
+        val roles = listOf("ROLE_USER", "ROLE_ADMIN")
+        val isActivated = true
+
+        // When
+        val claims = JwtClaims(
+            memberId = id.toString(),
+            email = email,
+            roles = roles,
+            isActivated = isActivated
+        )
+
+        // Then
+        claims.memberId shouldBe id.toString()
+        claims.email shouldBe email
+        claims.roles shouldBe roles
+        claims.isActivated shouldBe isActivated
+    }
+}

--- a/src/test/kotlin/kr/respectme/common/security/jwt/adapter/JwtAuthenticationAdapterTest.kt
+++ b/src/test/kotlin/kr/respectme/common/security/jwt/adapter/JwtAuthenticationAdapterTest.kt
@@ -1,0 +1,105 @@
+package kr.respectme.common.security.jwt.adapter
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.AnnotationSpec
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import kr.respectme.common.response.ApiResult
+import kr.respectme.common.security.jwt.adapter.dto.JwtAuthenticationRequirements
+import kr.respectme.common.security.jwt.adapter.dto.JwtValidateRequest
+
+class JwtAuthenticationAdapterTest: AnnotationSpec() {
+
+    private lateinit var requirementsRequester: JwtAuthenticationRequirementsRequestAdapter
+    private val serviceToken = "serviceToken"
+
+    @BeforeEach
+    fun setUp() {
+        requirementsRequester = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `생성자 테스트`() {
+        // Given
+        val requirements = JwtAuthenticationRequirements(
+            issuer = "testIssuer",
+            secret = "testSecret"
+        )
+
+        // When
+        every { requirementsRequester.request(serviceToken) } returns ApiResult(
+            status = 200,
+            message = "success",
+            data = requirements
+        )
+
+        // Then
+        shouldNotThrowAny {
+            val jwtAuthenticationAdapter = JwtAuthenticationAdapter(
+                jwtAuthenticationRequirementsRequestPort = requirementsRequester,
+                serviceToken = serviceToken
+            )
+        }
+    }
+
+    @Test
+    fun `정상 토큰 검증 테스트`() {
+        // Given
+        val requirements = JwtAuthenticationRequirements(
+            issuer = "https://identification.respect-me.kr",
+            secret = "test-secret"
+        )
+        val token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkZW50aWZpY2F0aW9uLnJlc3BlY3QtbWUua3IiLCJzdWIiOiIwMTkxN2Y3YS1hZWViLTdkNjAtODkzYi1lNGM3YzYwZmY5YjkiLCJlbWFpbCI6Im1lbWJlcjFAcmVzcGVjdC1tZS5rciIsIm5pY2tuYW1lIjoibWVtYmVyMUByZXNwZWN0LW1lLmtyIiwicm9sZXMiOlsiUk9MRV9NRU1CRVIiXSwiaXNBY3RpdmF0ZWQiOnRydWUsImlhdCI6MTc0Njc5ODE4OCwiZXhwIjozNjM4OTU4MTg4fQ.2XjWIvaMeC7unJCYIJy_IgSo4XlbPPwj_x32DZftuRk"
+        val jwtValidationRequest = JwtValidateRequest(type = "Bearer", accessToken = token)
+
+        // When
+        every { requirementsRequester.request(serviceToken) } returns ApiResult(
+            status = 200,
+            message = "success",
+            data = requirements
+        )
+
+        // Then
+        shouldNotThrowAny {
+            val jwtAuthenticationAdapter = JwtAuthenticationAdapter(
+                jwtAuthenticationRequirementsRequestPort = requirementsRequester,
+                serviceToken = serviceToken
+            )
+            val result = jwtAuthenticationAdapter.verify(jwtValidationRequest)
+        }
+
+    }
+
+    @Test
+    fun `비정상 토큰 검증 테스트`() {
+// Given
+        val requirements = JwtAuthenticationRequirements(
+            issuer = "https://identification.respect-me.kr",
+            secret = "test-secret"
+        )
+        val token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkZW50aWZpY2F0aW9uLnJlc3BlY3QtbWUua3IiLCJzdWIiOiIwMTkxN2Y3YS1hZWViLTdkNjAtODkzYi1lNGM3YzYwZmY5YjkiLCJlbWFpbCI6Im1lbWJlcjFAcmVzcGVjdC1tZS5rciIsIm5pY2tuYW1lIjoibWVtYmVyMUByZXNwZWN0LW1lLmtyIiwicm9sZXMiOlsiUk9MRV9NRU1CRVIiXSwiaXNBY3RpdmF0ZWQiOnRydWUsImlhdCI6MTc0Njc5ODE4OCwiZXhwIjozNjM4OTU4MTg4fQ.2XjWIvaMeC7unJCYIJy_IgSo4XlbPPwj_x32DZftuR1"
+        val jwtValidationRequest = JwtValidateRequest(type = "Bearer", accessToken = token)
+
+        // When
+        every { requirementsRequester.request(serviceToken) } returns ApiResult(
+            status = 200,
+            message = "success",
+            data = requirements
+        )
+        val jwtAuthenticationAdapter = JwtAuthenticationAdapter(
+            jwtAuthenticationRequirementsRequestPort = requirementsRequester,
+            serviceToken = serviceToken
+        )
+        // Then
+        shouldThrowAny {
+            jwtAuthenticationAdapter.verify(jwtValidationRequest)
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+}

--- a/src/test/kotlin/kr/respectme/common/support/jwt/JwtAuthenticationSupport.kt
+++ b/src/test/kotlin/kr/respectme/common/support/jwt/JwtAuthenticationSupport.kt
@@ -1,0 +1,25 @@
+package kr.respectme.common.support.jwt
+
+import kr.respectme.common.security.jwt.JwtAuthentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import java.util.UUID
+
+class JwtAuthenticationSupport {
+
+    companion object {
+
+        fun createJwtAuthentication(
+            id: UUID = UUID.randomUUID(),
+            email: String = "test@email.com",
+            roles: List<String> = listOf("ROLE_MEMBER"),
+            isActivated: Boolean = true
+        ): JwtAuthentication {
+            return JwtAuthentication(
+                id = id,
+                email = email,
+                roles = roles.map{ role -> SimpleGrantedAuthority(role) }.toMutableList(),
+                isActivated = isActivated
+            )
+        }
+    }
+}


### PR DESCRIPTION
# 추가 사항
- Security Package Jwt Module 테스트 코드 추가
 
# 수정 사항
- DefaultJwtAuthenticationConfig의 @ConditionalOnProperty의 prefix 오탈자 수정
- JwtAuthenticationToken의 isAuthenticated 반환 식 수정 
```kotlin
// 기존 
    override fun isAuthenticated(): Boolean {
        return !(_principal as JwtAuthentication).isActivated
    }

// 변경
    override fun isAuthenticated(): Boolean {
        return (_principal as JwtAuthentication).isActivated
    }
```